### PR TITLE
pre-commit workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -1,0 +1,20 @@
+name: Pre-commit auto-update
+on:
+  schedule:
+  - cron: 0 0 1 * *
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - name: Install pre-commit
+      shell: bash -l {0}
+      run: pip install pre-commit
+    - name: Run pre-commit autoupdate
+      shell: bash -l {0}
+      run: |
+        pre-commit autoupdate -c .pre-commit-config.yaml
+        pre-commit autoupdate -c "{{cookiecutter.project_slug}}/.pre-commit-config.yaml"
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,15 @@
+name: pre-commit
+
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.3.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-json
+  - id: check-yaml
+  - id: check-toml
+  - id: check-added-large-files
+  - id: mixed-line-ending
+- repo: https://github.com/executablebooks/mdformat
+  rev: 0.7.14
+  hooks:
+  - id: mdformat
+- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+  rev: v2.3.0
+  hooks:
+  - id: pretty-format-yaml
+    args: [--autofix]
+  - id: pretty-format-toml
+    args: [--autofix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.2.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer

--- a/{{cookiecutter.project_slug}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_slug}}/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly

--- a/{{cookiecutter.project_slug}}/.github/workflows/pre-commit.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/pre-commit.yml
@@ -1,0 +1,15 @@
+name: pre-commit
+
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.2.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -39,3 +39,7 @@ repos:
     args: [--autofix]
   - id: pretty-format-toml
     args: [--autofix]
+- repo: https://github.com/cruft/cruft
+  rev: 2.10.2
+  hooks:
+  - id: cruft


### PR DESCRIPTION
- [x] We should probably use and run `pre-commit` also in this repo (e.g., add `.pre-commit.yml` under `cookiecutter-conda-package`)
- [x] Add an action that periodically updates the pinned version of the hooks. `cruft` will then sync the other packages
- [x] Review the hooks currently implemented (e.g., issues with prettifiers and VSCode)

cc: @alexamici 