### PR TITLE
cancel concurrent jobs

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/on-push.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/on-push.yml
@@ -10,6 +10,10 @@ on:
     branches:
     - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
@alexamici Do we want to cancel concurrent jobs (e.g., when many commits are pushed in a short time-frame)?