### PR TITLE
pin python 3.10

### DIFF
--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -16,6 +16,7 @@ long_description = file: README.md
 
 [options]
 packages = find:
+python_requires = >=3.10, <3.11
 
 [flake8]
 max-line-length = 110


### PR DESCRIPTION
This would make `setup.cfg` consistent with the python versions tested and with the `classifiers` metadata