### PR TITLE
switch to micromamba

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/on-push.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/on-push.yml
@@ -32,17 +32,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Cache conda
-      uses: actions/cache@v3
+    - name: Install Conda environment with Micromamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        path: ~/conda_pkgs_dir
-        key: ubuntu-latest-3.10
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        channels: conda-forge
-        mamba-version: '*'
-        python-version: '3.10'
         environment-file: environment.yml
+        environment-name: DEVELOP
+        channels: conda-forge
+        cache-env: true
+        cache-env-key: ubuntu-latest-3.10
+        extra-specs: |
+          python=3.10
     - name: Install package
       run: |
         python -m pip install --no-deps -e .
@@ -59,17 +58,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Cache conda
-      uses: actions/cache@v3
+    - name: Install Conda environment with Micromamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        path: ~/conda_pkgs_dir
-        key: ubuntu-latest-3.10
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        channels: conda-forge
-        mamba-version: '*'
-        python-version: '3.10'
         environment-file: environment.yml
+        environment-name: DEVELOP
+        channels: conda-forge
+        cache-env: true
+        cache-env-key: ubuntu-latest-3.10
+        extra-specs: |
+          python=3.10
     - name: Install package
       run: |
         python -m pip install --no-deps -e .
@@ -92,17 +90,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Cache conda
-      uses: actions/cache@v3
+    - name: Install Conda environment with Micromamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        path: ~/conda_pkgs_dir
-        key: ubuntu-latest-${{ '{{ matrix.python-version }}' }}${{ '{{ matrix.extra }}' }}
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
+        environment-file: environment${{ matrix.extra }}.yml
+        environment-name: DEVELOP${{ matrix.extra }}
         channels: conda-forge
-        mamba-version: '*'
-        python-version: ${{ '{{ matrix.python-version }}' }}
-        environment-file: environment${{ '{{ matrix.extra }}' }}.yml
+        cache-env: true
+        cache-env-key: ubuntu-latest-${{ matrix.python-version }}${{ matrix.extra }}
+        extra-specs: |
+          python=${{ matrix.python-version }}
     - name: Install package
       run: |
         python -m pip install --no-deps -e .


### PR DESCRIPTION
micromamba is lighter/faster and we can use a single action to install and cache conda